### PR TITLE
fix: cutlass python kernel generate env setup method

### DIFF
--- a/3rdparty/LLM_kernels/csrc/kernels/nvidia/asymmetric_gemm/CMakeLists.txt
+++ b/3rdparty/LLM_kernels/csrc/kernels/nvidia/asymmetric_gemm/CMakeLists.txt
@@ -71,10 +71,10 @@ endif()
 if(NEED_REGENERATE)
   message(STATUS "Regenerating CUTLASS kernels...")
   
-  # 设置CUTLASS库
+  # NOTE(karlluo): setup cutlass python environment refer to: https://github.com/NVIDIA/cutlass/tree/main/python#installation
   execute_process(
-    WORKING_DIRECTORY ${3RDPARTY_DIR}/cutlass/python/
-    COMMAND ${Python3_EXECUTABLE} setup_library.py develop --user
+    WORKING_DIRECTORY ${3RDPARTY_DIR}/cutlass
+    COMMAND ${Python3_EXECUTABLE} -m pip install -e .
     RESULT_VARIABLE _CUTLASS_LIBRARY_SUCCESS)
 
   if(NOT _CUTLASS_LIBRARY_SUCCESS MATCHES 0)

--- a/3rdparty/LLM_kernels/csrc/kernels/nvidia/machete/CMakeLists.txt
+++ b/3rdparty/LLM_kernels/csrc/kernels/nvidia/machete/CMakeLists.txt
@@ -58,10 +58,10 @@ endif()
 if(NEED_REGENERATE)
   message(STATUS "Regenerating machete kernels...")
   
-  # 设置CUTLASS库
+  # NOTE(karlluo): setup cutlass python environment refer to: https://github.com/NVIDIA/cutlass/tree/main/python#installation
   execute_process(
-    WORKING_DIRECTORY ${3RDPARTY_DIR}/cutlass/python/
-    COMMAND ${Python3_EXECUTABLE} setup_library.py develop --user
+    WORKING_DIRECTORY ${3RDPARTY_DIR}/cutlass
+    COMMAND ${Python3_EXECUTABLE} -m pip install -e .
     RESULT_VARIABLE _CUTLASS_LIBRARY_SUCCESS)
 
   if(NOT _CUTLASS_LIBRARY_SUCCESS MATCHES 0)


### PR DESCRIPTION
for higher python version like python3.11. setup.py is deprecated, so we change to pip install to setup cutlass python environment.